### PR TITLE
Add occurrences for misses

### DIFF
--- a/backend/integration_test/elasticsearch/log_processor_test.go
+++ b/backend/integration_test/elasticsearch/log_processor_test.go
@@ -15,7 +15,7 @@ func TestUpdates(t *testing.T) {
 	if es == nil {
 		t.Error("es is uninitialized or otherwise nil")
 	}
-	ac := elasticsearch.NewAugurClientImpl(es, elasticsearch.Wait)
+	ac := elasticsearch.NewAugurClientImpl(es, elasticsearch.Immediate)
 	logProcessor := service.NewLogProcessorService(ac, logger)
 	t.Run("should be able to process and update logs of the same type", func(t *testing.T) {
 		err := deleteAllDocuments(es)

--- a/backend/pkg/count/service/count_service.go
+++ b/backend/pkg/count/service/count_service.go
@@ -212,7 +212,10 @@ func (cs *CountService) increaseOccurrencesForMisses(
 		)
 		return fmt.Errorf("error marshaling increment query: %w", err)
 	}
-	return cs.ac.UpdateByQuery(ctx, string(queryBody), indices)
+	updateIndices := []string{elasticsearch.CountIndexName}
+	updateCtx, cancel := context.WithTimeout(ctx, csTimeOut)
+	defer cancel()
+	return cs.ac.UpdateByQuery(updateCtx, string(queryBody), updateIndices)
 }
 
 func groupCoOccurringClustersByClusterId(clusters []model.Cluster) map[string][]model.Cluster {

--- a/backend/pkg/count/service/query_builder.go
+++ b/backend/pkg/count/service/query_builder.go
@@ -95,3 +95,32 @@ func countCoOccurrencesQueryBuilder(clusterId string, fromTime time.Time, toTime
 		},
 	}
 }
+
+func incrementNonMatchedClusterIds(coOccurringClusterId string, matchedClusterIds []string) map[string]interface{} {
+	return map[string]interface{}{
+		"script": map[string]interface{}{
+			"source": "ctx._source.occurrences += params.increment",
+			"params": map[string]interface{}{
+				"increment": 1,
+			},
+		},
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"must": []map[string]interface{}{
+					{
+						"term": map[string]interface{}{
+							"co_cluster_id": coOccurringClusterId,
+						},
+					},
+				},
+				"must_not": []map[string]interface{}{
+					{
+						"terms": map[string]interface{}{
+							"cluster_id": matchedClusterIds,
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
The aim of this PR is to change how we increment Occurrences. Previously we were doing it in an idiotic way - taking a larger bucket and counting misses. Now we do it correctly - any documents that have a pre-existing co-occurrences/occurrences will have its occurrences incremented by 1 for each corresponding co-cluster that is unable to find its partner cluster during a count.