### PR TITLE
Make misses counted after

### DIFF
--- a/backend/cmd/cluster_counter/main.go
+++ b/backend/cmd/cluster_counter/main.go
@@ -308,7 +308,7 @@ func main() {
 	resultChannel := ac.SearchAfter(
 		searchCtx,
 		queryMap,
-		[]string{bootstrapper.SpanIndexName, bootstrapper.LogIndexName},
+		[]string{bootstrapper.SpanIndexName},
 		nil,
 		&querySize,
 	)

--- a/backend/cmd/cluster_counter/main.go
+++ b/backend/cmd/cluster_counter/main.go
@@ -199,9 +199,7 @@ func processData(
 		if result == nil {
 			continue
 		}
-		if len(result.IncreaseIncrementForMissesInput.CoClusterIds) > 0 {
-			increaseMissesList = append(increaseMissesList, result.IncreaseIncrementForMissesInput)
-		}
+		increaseMissesList = append(increaseMissesList, result.IncreaseIncrementForMissesInput)
 		if result.MetaMapList != nil && len(result.MetaMapList) > 0 {
 			if result.DocumentMapList == nil || len(result.DocumentMapList) == 0 {
 				logger.Fatal("DocumentMapList is nil or empty, despite MetaMapList being non-empty")

--- a/backend/integration_test/elasticsearch/count_service_test.go
+++ b/backend/integration_test/elasticsearch/count_service_test.go
@@ -97,7 +97,7 @@ func TestLogCount(t *testing.T) {
 		buckets := []countService.Bucket{2500}
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		err = cs.CountAndUpdateOccurrences(
+		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			ctx,
 			newLog.ClusterId,
 			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},
@@ -143,7 +143,7 @@ func TestLogCount(t *testing.T) {
 		buckets := []countService.Bucket{2500}
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		err = cs.CountAndUpdateOccurrences(
+		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			ctx,
 			newLog.ClusterId,
 			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},
@@ -152,7 +152,7 @@ func TestLogCount(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to count occurrences: %v", err)
 		}
-		err = cs.CountAndUpdateOccurrences(
+		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			ctx,
 			newLog.ClusterId,
 			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},
@@ -208,7 +208,7 @@ func TestLogCount(t *testing.T) {
 		buckets := []countService.Bucket{2500}
 		firstCtx, firstCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer firstCancel()
-		err = cs.CountAndUpdateOccurrences(
+		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			firstCtx,
 			newLog.ClusterId,
 			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},
@@ -219,7 +219,7 @@ func TestLogCount(t *testing.T) {
 		}
 		secondCtx, secondCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer secondCancel()
-		err = cs.CountAndUpdateOccurrences(
+		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			secondCtx,
 			logsOfDifferentTime[0].ClusterId,
 			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: logsOfDifferentTime[0].Timestamp}},
@@ -277,7 +277,7 @@ func TestLogCount(t *testing.T) {
 		buckets := []countService.Bucket{2500}
 		missCtx, missCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer missCancel()
-		err = cs.CountAndUpdateOccurrences(
+		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			missCtx,
 			logsOfDifferentTime[0].ClusterId,
 			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: logsOfDifferentTime[0].Timestamp}},
@@ -288,7 +288,7 @@ func TestLogCount(t *testing.T) {
 		}
 		hitCtx, hitCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer hitCancel()
-		err = cs.CountAndUpdateOccurrences(
+		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			hitCtx,
 			newLog.ClusterId,
 			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},
@@ -462,7 +462,7 @@ func TestSpanCount(t *testing.T) {
 		buckets := []countService.Bucket{1000}
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		err = cs.CountAndUpdateOccurrences(
+		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			ctx,
 			newSpan.ClusterId,
 			countService.TimeInfo{
@@ -475,7 +475,7 @@ func TestSpanCount(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to count occurrences: %v", err)
 		}
-		err = cs.CountAndUpdateOccurrences(
+		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			ctx,
 			newSpan.ClusterId,
 			countService.TimeInfo{
@@ -536,7 +536,7 @@ func TestAlgorithm(t *testing.T) {
 		buckets := []countService.Bucket{2500}
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		err = cs.CountAndUpdateOccurrences(
+		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			ctx,
 			newLog.ClusterId,
 			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},

--- a/backend/integration_test/elasticsearch/count_service_test.go
+++ b/backend/integration_test/elasticsearch/count_service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Avi18971911/Augur/pkg/log/model"
 	spanModel "github.com/Avi18971911/Augur/pkg/trace/model"
 	"github.com/stretchr/testify/assert"
+	"slices"
 	"testing"
 	"time"
 )
@@ -59,7 +60,7 @@ func TestLogCount(t *testing.T) {
 		countInfo, err := cs.CountOccurrencesAndCoOccurrencesByCoClusterId(
 			ctx,
 			newLog.ClusterId,
-			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},
+			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
 			buckets,
 		)
 		if err != nil {
@@ -97,14 +98,18 @@ func TestLogCount(t *testing.T) {
 		buckets := []countService.Bucket{2500}
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
+		res, err := cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			ctx,
 			newLog.ClusterId,
-			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},
+			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
 			buckets,
 		)
 		if err != nil {
 			t.Errorf("Failed to count occurrences: %v", err)
+		}
+		err = ac.BulkIndex(ctx, res.MetaMapList, res.DocumentMapList, bootstrapper.CountIndexName)
+		if err != nil {
+			t.Errorf("Failed to insert records: %v", err)
 		}
 		searchQueryBody := countQuery(newLog.ClusterId)
 		docs, err := ac.Search(ctx, searchQueryBody, []string{bootstrapper.CountIndexName}, &querySize)
@@ -141,25 +146,33 @@ func TestLogCount(t *testing.T) {
 			t.Error("Failed to load logs into elasticsearch")
 		}
 		buckets := []countService.Bucket{2500}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
+		res, err := cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			ctx,
 			newLog.ClusterId,
-			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},
+			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
 			buckets,
 		)
 		if err != nil {
 			t.Errorf("Failed to count occurrences: %v", err)
 		}
-		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
+		err = ac.BulkIndex(ctx, res.MetaMapList, res.DocumentMapList, bootstrapper.CountIndexName)
+		if err != nil {
+			t.Errorf("Failed to insert records: %v", err)
+		}
+		res, err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			ctx,
 			newLog.ClusterId,
-			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},
+			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
 			buckets,
 		)
 		if err != nil {
 			t.Errorf("Failed to count occurrences: %v", err)
+		}
+		err = ac.BulkIndex(ctx, res.MetaMapList, res.DocumentMapList, bootstrapper.CountIndexName)
+		if err != nil {
+			t.Errorf("Failed to insert records: %v", err)
 		}
 		searchQueryBody := countQuery(newLog.ClusterId)
 		docs, err := ac.Search(ctx, searchQueryBody, []string{bootstrapper.CountIndexName}, &querySize)
@@ -208,25 +221,35 @@ func TestLogCount(t *testing.T) {
 		buckets := []countService.Bucket{2500}
 		firstCtx, firstCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer firstCancel()
-		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
+		res, err := cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			firstCtx,
 			newLog.ClusterId,
-			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},
+			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
 			buckets,
 		)
 		if err != nil {
 			t.Errorf("Failed to count occurrences for successes: %v", err)
 		}
+		err = ac.BulkIndex(firstCtx, res.MetaMapList, res.DocumentMapList, bootstrapper.CountIndexName)
+		if err != nil {
+			t.Errorf("Failed to insert records: %v", err)
+		}
 		secondCtx, secondCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer secondCancel()
-		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
+		fakeInput := countModel.IncreaseMissesInput{
+			ClusterId:    newLog.ClusterId,
+			CoClusterIds: []string{},
+		}
+		missesRes, err := cs.GetIncrementMissesQueryInfo(
 			secondCtx,
-			logsOfDifferentTime[0].ClusterId,
-			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: logsOfDifferentTime[0].Timestamp}},
-			buckets,
+			fakeInput,
 		)
 		if err != nil {
 			t.Errorf("Failed to count occurrences for misses: %v", err)
+		}
+		err = ac.BulkIndex(secondCtx, missesRes.MetaMapList, missesRes.DocumentMapList, bootstrapper.CountIndexName)
+		if err != nil {
+			t.Errorf("Failed to insert records: %v", err)
 		}
 		queryCtx, queryCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer queryCancel()
@@ -277,25 +300,35 @@ func TestLogCount(t *testing.T) {
 		buckets := []countService.Bucket{2500}
 		missCtx, missCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer missCancel()
-		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
+		res, err := cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			missCtx,
 			logsOfDifferentTime[0].ClusterId,
-			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: logsOfDifferentTime[0].Timestamp}},
+			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: logsOfDifferentTime[0].Timestamp}},
 			buckets,
 		)
 		if err != nil {
 			t.Errorf("Failed to count occurrences for misses: %v", err)
 		}
+		insertCtx, insertCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer insertCancel()
+		err = ac.BulkIndex(insertCtx, res.MetaMapList, res.DocumentMapList, bootstrapper.CountIndexName)
+		if err != nil {
+			t.Errorf("Failed to insert records: %v", err)
+		}
 		hitCtx, hitCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer hitCancel()
-		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
+		res, err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			hitCtx,
 			newLog.ClusterId,
-			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},
+			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
 			buckets,
 		)
 		if err != nil {
 			t.Errorf("Failed to count occurrences for successes: %v", err)
+		}
+		err = ac.BulkIndex(insertCtx, res.MetaMapList, res.DocumentMapList, bootstrapper.CountIndexName)
+		if err != nil {
+			t.Errorf("Failed to insert records: %v", err)
 		}
 		queryCtx, queryCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer queryCancel()
@@ -357,8 +390,8 @@ func TestSpanCount(t *testing.T) {
 		countInfo, err := cs.CountOccurrencesAndCoOccurrencesByCoClusterId(
 			ctx,
 			newSpan.ClusterId,
-			countService.TimeInfo{
-				SpanInfo: &countService.SpanInfo{
+			countModel.TimeInfo{
+				SpanInfo: &countModel.SpanInfo{
 					FromTime: newSpan.StartTime, ToTime: newSpan.EndTime,
 				},
 			},
@@ -411,8 +444,8 @@ func TestSpanCount(t *testing.T) {
 		countInfo, err := cs.CountOccurrencesAndCoOccurrencesByCoClusterId(
 			ctx,
 			newSpan.ClusterId,
-			countService.TimeInfo{
-				SpanInfo: &countService.SpanInfo{
+			countModel.TimeInfo{
+				SpanInfo: &countModel.SpanInfo{
 					FromTime: newSpan.StartTime, ToTime: newSpan.EndTime,
 				},
 			},
@@ -462,11 +495,11 @@ func TestSpanCount(t *testing.T) {
 		buckets := []countService.Bucket{1000}
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
+		res, err := cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			ctx,
 			newSpan.ClusterId,
-			countService.TimeInfo{
-				SpanInfo: &countService.SpanInfo{
+			countModel.TimeInfo{
+				SpanInfo: &countModel.SpanInfo{
 					FromTime: newSpan.StartTime, ToTime: newSpan.EndTime,
 				},
 			},
@@ -475,16 +508,24 @@ func TestSpanCount(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to count occurrences: %v", err)
 		}
-		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
+		err = ac.BulkIndex(ctx, res.MetaMapList, res.DocumentMapList, bootstrapper.CountIndexName)
+		if err != nil {
+			t.Errorf("Failed to insert records: %v", err)
+		}
+		res, err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			ctx,
 			newSpan.ClusterId,
-			countService.TimeInfo{
-				SpanInfo: &countService.SpanInfo{
+			countModel.TimeInfo{
+				SpanInfo: &countModel.SpanInfo{
 					FromTime: newSpan.StartTime, ToTime: newSpan.EndTime,
 				},
 			},
 			buckets,
 		)
+		err = ac.BulkIndex(ctx, res.MetaMapList, res.DocumentMapList, bootstrapper.CountIndexName)
+		if err != nil {
+			t.Errorf("Failed to insert records: %v", err)
+		}
 		if err != nil {
 			t.Errorf("Failed to count occurrences: %v", err)
 		}
@@ -536,14 +577,18 @@ func TestAlgorithm(t *testing.T) {
 		buckets := []countService.Bucket{2500}
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		err = cs.GetCountAndUpdateOccurrencesQueryConstituents(
+		res, err := cs.GetCountAndUpdateOccurrencesQueryConstituents(
 			ctx,
 			newLog.ClusterId,
-			countService.TimeInfo{LogInfo: &countService.LogInfo{Timestamp: newLog.Timestamp}},
+			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
 			buckets,
 		)
 		if err != nil {
 			t.Errorf("Failed to count occurrences: %v", err)
+		}
+		err = ac.BulkIndex(ctx, res.MetaMapList, res.DocumentMapList, bootstrapper.CountIndexName)
+		if err != nil {
+			t.Errorf("Failed to insert records: %v", err)
 		}
 		searchQueryBody := countQuery(newLog.ClusterId)
 		var querySize = 100
@@ -557,7 +602,10 @@ func TestAlgorithm(t *testing.T) {
 		}
 		assert.Equal(t, 2, len(countEntries))
 		coClusters := []string{countEntries[0].CoClusterId, countEntries[1].CoClusterId}
-		assert.EqualValues(t, []string{logWithClusterId1.ClusterId, logWithClusterId2.ClusterId}, coClusters)
+		slices.Sort(coClusters)
+		expectedResult := []string{"clusterId1", "clusterId2"}
+		slices.Sort(expectedResult)
+		assert.EqualValues(t, expectedResult, coClusters)
 	})
 }
 
@@ -568,7 +616,7 @@ func loadDataIntoElasticsearch[Data any](ac client.AugurClient, data []Data) err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	err = ac.BulkIndex(ctx, dataMap, metaMap, bootstrapper.LogIndexName)
+	err = ac.BulkIndex(ctx, metaMap, dataMap, bootstrapper.LogIndexName)
 	if err != nil {
 		return err
 	}

--- a/backend/integration_test/elasticsearch/count_service_test.go
+++ b/backend/integration_test/elasticsearch/count_service_test.go
@@ -237,8 +237,8 @@ func TestLogCount(t *testing.T) {
 		secondCtx, secondCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer secondCancel()
 		fakeInput := countModel.IncreaseMissesInput{
-			ClusterId:    newLog.ClusterId,
-			CoClusterIds: []string{},
+			ClusterId:             newLog.ClusterId,
+			CoClusterIdsToExclude: []string{},
 		}
 		missesRes, err := cs.GetIncrementMissesQueryInfo(
 			secondCtx,
@@ -300,8 +300,8 @@ func TestLogCount(t *testing.T) {
 		missCtx, missCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer missCancel()
 		fakeInput := countModel.IncreaseMissesInput{
-			ClusterId:    newLog.ClusterId,
-			CoClusterIds: []string{},
+			ClusterId:             newLog.ClusterId,
+			CoClusterIdsToExclude: []string{},
 		}
 		missRes, err := cs.GetIncrementMissesQueryInfo(
 			missCtx,

--- a/backend/pkg/cache/write_behind_cache.go
+++ b/backend/pkg/cache/write_behind_cache.go
@@ -101,8 +101,8 @@ func (wbc *WriteBehindCacheImpl[ValueType]) flushToElasticsearch(ctx context.Con
 	}
 	err = wbc.ac.BulkIndex(
 		bulkCtx,
-		dataMap,
 		metaMap,
+		dataMap,
 		wbc.esIndexName,
 	)
 	wbc.writeQueue = []ValueType{}

--- a/backend/pkg/count/model/cluster.go
+++ b/backend/pkg/count/model/cluster.go
@@ -1,5 +1,6 @@
 package model
 
 type Cluster struct {
-	ClusterId string `json:"cluster_id"`
+	ClusterId   string `json:"cluster_id"`
+	CoClusterId string `json:"co_cluster_id"`
 }

--- a/backend/pkg/count/model/query_constituents.go
+++ b/backend/pkg/count/model/query_constituents.go
@@ -1,10 +1,9 @@
 package model
 
-type MetaMap map[string]interface{}
-type DocumentMap map[string]interface{}
+import "github.com/Avi18971911/Augur/pkg/elasticsearch/client"
 
 type GetCountAndUpdateOccurrencesQueryConstituentsResult struct {
 	ClusterIds      []string
-	MetaMapList     []MetaMap
-	DocumentMapList []DocumentMap
+	MetaMapList     []client.MetaMap
+	DocumentMapList []client.DocumentMap
 }

--- a/backend/pkg/count/model/query_constituents.go
+++ b/backend/pkg/count/model/query_constituents.go
@@ -3,8 +3,8 @@ package model
 import "github.com/Avi18971911/Augur/pkg/elasticsearch/client"
 
 type IncreaseMissesInput struct {
-	ClusterId    string
-	CoClusterIds []string
+	ClusterId             string
+	CoClusterIdsToExclude []string
 }
 
 type GetCountAndUpdateOccurrencesQueryConstituentsResult struct {

--- a/backend/pkg/count/model/query_constituents.go
+++ b/backend/pkg/count/model/query_constituents.go
@@ -1,0 +1,10 @@
+package model
+
+type MetaMap map[string]interface{}
+type DocumentMap map[string]interface{}
+
+type GetCountAndUpdateOccurrencesQueryConstituentsResult struct {
+	ClusterIds      []string
+	MetaMapList     []MetaMap
+	DocumentMapList []DocumentMap
+}

--- a/backend/pkg/count/model/query_constituents.go
+++ b/backend/pkg/count/model/query_constituents.go
@@ -2,8 +2,18 @@ package model
 
 import "github.com/Avi18971911/Augur/pkg/elasticsearch/client"
 
+type IncreaseMissesInput struct {
+	ClusterId    string
+	CoClusterIds []string
+}
+
 type GetCountAndUpdateOccurrencesQueryConstituentsResult struct {
-	ClusterIds      []string
+	IncreaseIncrementForMissesInput IncreaseMissesInput
+	MetaMapList                     []client.MetaMap
+	DocumentMapList                 []client.DocumentMap
+}
+
+type GetMetaAndDocumentInfoForIncrementMissesQueryResult struct {
 	MetaMapList     []client.MetaMap
 	DocumentMapList []client.DocumentMap
 }

--- a/backend/pkg/count/model/time_info.go
+++ b/backend/pkg/count/model/time_info.go
@@ -1,0 +1,22 @@
+package model
+
+import "time"
+
+type LogInfo struct {
+	Timestamp time.Time
+}
+
+type SpanInfo struct {
+	FromTime time.Time
+	ToTime   time.Time
+}
+
+type CalculatedTimeInfo struct {
+	FromTime time.Time
+	ToTime   time.Time
+}
+
+type TimeInfo struct {
+	SpanInfo *SpanInfo
+	LogInfo  *LogInfo
+}

--- a/backend/pkg/count/service/count_service.go
+++ b/backend/pkg/count/service/count_service.go
@@ -233,7 +233,7 @@ func (cs *CountService) getIncrementMissesDetails(
 	metaMap := make([]client.MetaMap, len(missingCoClusterIds))
 	updateMap := make([]client.DocumentMap, len(missingCoClusterIds))
 	for i, missingCoClusterId := range missingCoClusterIds {
-		compositeKey := getIDFromConstituents(clusterId, missingCoClusterId.ClusterId)
+		compositeKey := getIDFromConstituents(clusterId, missingCoClusterId.CoClusterId)
 		meta, update := buildIncrementNonMatchedCoClusterIdsQuery(compositeKey)
 		metaMap[i] = meta
 		updateMap[i] = update

--- a/backend/pkg/count/service/count_service.go
+++ b/backend/pkg/count/service/count_service.go
@@ -64,8 +64,8 @@ func getIncrementOccurrencesForMissesInput(
 		i++
 	}
 	return model.IncreaseMissesInput{
-		ClusterId:    clusterId,
-		CoClusterIds: clusterIds,
+		ClusterId:             clusterId,
+		CoClusterIdsToExclude: clusterIds,
 	}
 }
 
@@ -174,7 +174,7 @@ func (cs *CountService) GetIncrementMissesQueryInfo(
 	ctx context.Context,
 	input model.IncreaseMissesInput,
 ) (*model.GetMetaAndDocumentInfoForIncrementMissesQueryResult, error) {
-	missingCoClusterIds, err := cs.getNonMatchingCoClusterIds(ctx, input.ClusterId, input.CoClusterIds)
+	missingCoClusterIds, err := cs.getNonMatchingCoClusterIds(ctx, input.ClusterId, input.CoClusterIdsToExclude)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/count/service/query_builder.go
+++ b/backend/pkg/count/service/query_builder.go
@@ -54,9 +54,9 @@ func buildGetCoOccurringClustersQuery(clusterId string, fromTime time.Time, toTi
 	}
 }
 
-func buildGetNonMatchedClusterIdsQuery(
-	coOccurringClusterId string,
-	matchedClusterIds []string,
+func buildGetNonMatchedCoClusterIdsQuery(
+	clusterId string,
+	matchedCoClusterIds []string,
 ) map[string]interface{} {
 	return map[string]interface{}{
 		"query": map[string]interface{}{
@@ -64,24 +64,24 @@ func buildGetNonMatchedClusterIdsQuery(
 				"must": []map[string]interface{}{
 					{
 						"term": map[string]interface{}{
-							"co_cluster_id": coOccurringClusterId,
+							"cluster_id": clusterId,
 						},
 					},
 				},
 				"must_not": []map[string]interface{}{
 					{
 						"terms": map[string]interface{}{
-							"cluster_id": matchedClusterIds,
+							"co_cluster_id": matchedCoClusterIds,
 						},
 					},
 				},
 			},
 		},
-		"_source": []string{"cluster_id"}, // Retrieve only the cluster IDs
+		"_source": []string{"co_cluster_id"}, // Retrieve only the co-cluster IDs
 	}
 }
 
-func buildUpdateNonMatchedClusterIdsQuery(
+func buildIncrementNonMatchedCoClusterIdsQuery(
 	id string,
 ) (client.MetaMap, client.DocumentMap) {
 	updateStatement := map[string]interface{}{

--- a/backend/pkg/count/service/query_builder.go
+++ b/backend/pkg/count/service/query_builder.go
@@ -82,7 +82,7 @@ func buildGetNonMatchedClusterIdsQuery(
 
 func buildUpdateNonMatchedClusterIdsQuery(
 	id string,
-) (map[string]interface{}, map[string]interface{}) {
+) (MetaMap, DocumentMap) {
 	updateStatement := map[string]interface{}{
 		"script": map[string]interface{}{
 			"source": "ctx._source.occurrences += params.increment",
@@ -106,7 +106,7 @@ func buildUpdateClusterCountsQuery(
 	clusterId string,
 	otherClusterId string,
 	countInfo CountInfo,
-) (map[string]interface{}, map[string]interface{}) {
+) (MetaMap, DocumentMap) {
 	updateStatement := map[string]interface{}{
 		"script": map[string]interface{}{
 			"source": "ctx._source.occurrences += params.occurrences; ctx._source.co_occurrences += params.co_occurrences",

--- a/backend/pkg/count/service/query_builder.go
+++ b/backend/pkg/count/service/query_builder.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"github.com/Avi18971911/Augur/pkg/elasticsearch/bootstrapper"
+	"github.com/Avi18971911/Augur/pkg/elasticsearch/client"
 	"time"
 )
 
@@ -82,7 +83,7 @@ func buildGetNonMatchedClusterIdsQuery(
 
 func buildUpdateNonMatchedClusterIdsQuery(
 	id string,
-) (MetaMap, DocumentMap) {
+) (client.MetaMap, client.DocumentMap) {
 	updateStatement := map[string]interface{}{
 		"script": map[string]interface{}{
 			"source": "ctx._source.occurrences += params.increment",
@@ -106,7 +107,7 @@ func buildUpdateClusterCountsQuery(
 	clusterId string,
 	otherClusterId string,
 	countInfo CountInfo,
-) (MetaMap, DocumentMap) {
+) (client.MetaMap, client.DocumentMap) {
 	updateStatement := map[string]interface{}{
 		"script": map[string]interface{}{
 			"source": "ctx._source.occurrences += params.occurrences; ctx._source.co_occurrences += params.co_occurrences",

--- a/backend/pkg/elasticsearch/client/augur_client.go
+++ b/backend/pkg/elasticsearch/client/augur_client.go
@@ -21,10 +21,10 @@ const (
 type AugurClient interface {
 	// BulkIndex indexes (inserts) multiple documents in the same index
 	// https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html
-	BulkIndex(ctx context.Context, data []map[string]interface{}, metaInfo []map[string]interface{}, index string) error
+	BulkIndex(ctx context.Context, metaInfo []MetaMap, documentInfo []DocumentMap, index string) error
 	// Index indexes (inserts) a single document in the index
 	// https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html
-	Index(ctx context.Context, data map[string]interface{}, metaInfo map[string]interface{}, index string) error
+	Index(ctx context.Context, metaInfo MetaMap, documentInfo DocumentMap, index string) error
 	// Search searches for documents in the index
 	// https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html
 	// queryResultSize is the number of results to return, -1 for default

--- a/backend/pkg/elasticsearch/client/augur_client_mutations.go
+++ b/backend/pkg/elasticsearch/client/augur_client_mutations.go
@@ -83,12 +83,12 @@ func (a *AugurClientImpl) Upsert(
 
 func (a *AugurClientImpl) BulkIndex(
 	ctx context.Context,
-	data []map[string]interface{},
-	metaInfo []map[string]interface{},
+	metaInfo []MetaMap,
+	documentInfo []DocumentMap,
 	index string,
 ) error {
 	var buf bytes.Buffer
-	for i, d := range data {
+	for i, d := range documentInfo {
 		var meta map[string]interface{}
 		if metaInfo != nil && i < len(metaInfo) {
 			meta = metaInfo[i]
@@ -105,7 +105,7 @@ func (a *AugurClientImpl) BulkIndex(
 
 		dataJSON, err := json.Marshal(d)
 		if err != nil {
-			return fmt.Errorf("error marshaling data to bulk index: %w", err)
+			return fmt.Errorf("error marshaling documentInfo to bulk index: %w", err)
 		}
 		buf.Write(dataJSON)
 		buf.WriteByte('\n')
@@ -138,12 +138,12 @@ func (a *AugurClientImpl) BulkIndex(
 
 func (a *AugurClientImpl) Index(
 	ctx context.Context,
-	data map[string]interface{},
-	metaInfo map[string]interface{},
+	metaInfo MetaMap,
+	documentInfo DocumentMap,
 	index string,
 ) error {
 	if metaInfo == nil {
-		return a.BulkIndex(ctx, []map[string]interface{}{data}, nil, index)
+		return a.BulkIndex(ctx, nil, []DocumentMap{documentInfo}, index)
 	}
-	return a.BulkIndex(ctx, []map[string]interface{}{data}, []map[string]interface{}{metaInfo}, index)
+	return a.BulkIndex(ctx, []MetaMap{metaInfo}, []DocumentMap{documentInfo}, index)
 }

--- a/backend/pkg/elasticsearch/client/augur_client_util.go
+++ b/backend/pkg/elasticsearch/client/augur_client_util.go
@@ -40,18 +40,23 @@ func NormalizeTimestampToNanoseconds(timestamp string) (time.Time, error) {
 		timestamp = strings.TrimSuffix(timestamp, "Z")
 	}
 
-	parts := strings.SplitN(timestamp, ".", 2)
-	if len(parts) == 2 {
-		fractionalPart := parts[1]
+	// TODO: Handle HH:MM:SS case gracefully
+	if !strings.Contains(timestamp, ".") {
+		timestamp += ".000000000"
+	} else {
+		parts := strings.SplitN(timestamp, ".", 2)
+		if len(parts) == 2 {
+			fractionalPart := parts[1]
 
-		// 9 digits (nanosecond)
-		if len(fractionalPart) > 9 {
-			fractionalPart = fractionalPart[:9]
-		} else if len(fractionalPart) < 9 {
-			fractionalPart = fractionalPart + strings.Repeat("0", 9-len(fractionalPart))
+			// 9 digits (nanosecond)
+			if len(fractionalPart) > 9 {
+				fractionalPart = fractionalPart[:9]
+			} else if len(fractionalPart) < 9 {
+				fractionalPart = fractionalPart + strings.Repeat("0", 9-len(fractionalPart))
+			}
+
+			timestamp = parts[0] + "." + fractionalPart
 		}
-
-		timestamp = parts[0] + "." + fractionalPart
 	}
 
 	if isUTC {

--- a/backend/pkg/elasticsearch/client/augur_client_util.go
+++ b/backend/pkg/elasticsearch/client/augur_client_util.go
@@ -7,9 +7,12 @@ import (
 	"time"
 )
 
-func ToMetaAndDataMap[T any](values []T) ([]map[string]interface{}, []map[string]interface{}, error) {
-	dataMap := make([]map[string]interface{}, len(values))
-	metaMap := make([]map[string]interface{}, len(values))
+type MetaMap map[string]interface{}
+type DocumentMap map[string]interface{}
+
+func ToMetaAndDataMap[T any](values []T) ([]MetaMap, []DocumentMap, error) {
+	dataMap := make([]DocumentMap, len(values))
+	metaMap := make([]MetaMap, len(values))
 	for i, v := range values {
 		data, err := json.Marshal(v)
 		if err != nil {

--- a/sandbox/.gitignore
+++ b/sandbox/.gitignore
@@ -9,6 +9,8 @@
 .nb-gradle-properties
 .swp
 .DS_Store
+*.json
+*.sh
 \#*\#
 
 docker-compose.override.yml


### PR DESCRIPTION
We always needed to ensure that all counts are in before we actually do the miss counting. This PR implements that.