### PR TITLE
Change how to count occurrences

### DIFF
--- a/backend/integration_test/elasticsearch/count_service_test.go
+++ b/backend/integration_test/elasticsearch/count_service_test.go
@@ -24,106 +24,6 @@ func TestLogCount(t *testing.T) {
 
 	ac := client.NewAugurClientImpl(es, client.Immediate)
 	cs := countService.NewCountService(ac, logger)
-	t.Run("should be able to count co-occurrences of logs within the same timespan", func(t *testing.T) {
-		err := deleteAllDocuments(es)
-		if err != nil {
-			t.Errorf("Failed to delete all documents: %v", err)
-		}
-		numWithinBucket := 4
-		numOutsideBucket := 2
-		initialTime := time.Date(2021, 1, 1, 0, 0, 0, 204, time.UTC)
-		newLog := model.LogEntry{
-			ClusterId: "initialClusterId",
-			Timestamp: initialTime,
-		}
-		logsOfSameTime := makeLogsOfSameClusterId(
-			"differentTime",
-			initialTime.Add(time.Second),
-			numWithinBucket,
-		)
-		logsOfDifferentTime := makeLogsOfSameClusterId(
-			"differentTime",
-			initialTime.Add(time.Second*2),
-			numOutsideBucket,
-		)
-		err = loadDataIntoElasticsearch(ac, []model.LogEntry{newLog})
-		if err != nil {
-			t.Error("Failed to load logs into elasticsearch")
-		}
-		err = loadDataIntoElasticsearch(ac, append(logsOfSameTime, logsOfDifferentTime...))
-		if err != nil {
-			t.Error("Failed to load logs into elasticsearch")
-		}
-		buckets := []countService.Bucket{2500}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		countInfo, err := cs.CountOccurrencesAndCoOccurrencesByCoClusterId(
-			ctx,
-			newLog.ClusterId,
-			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
-			buckets,
-		)
-		if err != nil {
-			t.Errorf("Failed to count occurrences: %v", err)
-		}
-		relevantCountInfo := countInfo["differentTime"]
-		assert.Equal(t, int64(len(logsOfSameTime)), relevantCountInfo.Occurrences)
-		assert.Equal(t, int64(len(logsOfSameTime)), relevantCountInfo.CoOccurrences)
-	})
-
-	t.Run("should store new entries into the database if nothing else is there", func(t *testing.T) {
-		err := deleteAllDocuments(es)
-		if err != nil {
-			t.Errorf("Failed to delete all documents: %v", err)
-		}
-		numWithinBucket := 4
-		initialTime := time.Date(2021, 1, 1, 0, 0, 0, 204, time.UTC)
-		newLog := model.LogEntry{
-			ClusterId: "initialClusterId",
-			Timestamp: initialTime,
-		}
-		logsOfDifferentTime := makeLogsOfSameClusterId(
-			"differentTime",
-			initialTime.Add(time.Second),
-			numWithinBucket,
-		)
-		err = loadDataIntoElasticsearch(ac, logsOfDifferentTime)
-		if err != nil {
-			t.Error("Failed to load logs into elasticsearch")
-		}
-		err = loadDataIntoElasticsearch(ac, []model.LogEntry{newLog})
-		if err != nil {
-			t.Error("Failed to load logs into elasticsearch")
-		}
-		buckets := []countService.Bucket{2500}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		res, err := cs.GetCountAndUpdateOccurrencesQueryConstituents(
-			ctx,
-			newLog.ClusterId,
-			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
-			buckets,
-		)
-		if err != nil {
-			t.Errorf("Failed to count occurrences: %v", err)
-		}
-		err = ac.BulkIndex(ctx, res.MetaMapList, res.DocumentMapList, bootstrapper.CountIndexName)
-		if err != nil {
-			t.Errorf("Failed to insert records: %v", err)
-		}
-		searchQueryBody := countQuery(newLog.ClusterId)
-		docs, err := ac.Search(ctx, searchQueryBody, []string{bootstrapper.CountIndexName}, &querySize)
-		if err != nil {
-			t.Errorf("Failed to search for count: %v", err)
-		}
-		countEntries, err := convertCountDocsToCountEntries(docs)
-		if err != nil {
-			t.Errorf("Failed to convert count docs to count entries: %v", err)
-		}
-		countEntry := countEntries[0]
-		assert.Equal(t, int64(numWithinBucket), countEntry.Occurrences)
-		assert.Equal(t, int64(numWithinBucket), countEntry.CoOccurrences)
-	})
 
 	t.Run("should update existing entries in the database", func(t *testing.T) {
 		err := deleteAllDocuments(es)
@@ -184,8 +84,8 @@ func TestLogCount(t *testing.T) {
 			t.Errorf("Failed to convert count docs to count entries: %v", err)
 		}
 		countEntry := countEntries[0]
-		assert.Equal(t, int64(numWithinBucket*2), countEntry.Occurrences)
-		assert.Equal(t, int64(numWithinBucket*2), countEntry.CoOccurrences)
+		assert.Equal(t, int64(2), countEntry.Occurrences)
+		assert.Equal(t, int64(2), countEntry.CoOccurrences)
 	})
 
 	t.Run("should add occurrences for misses if co-occurrences have been found", func(t *testing.T) {
@@ -263,8 +163,8 @@ func TestLogCount(t *testing.T) {
 			t.Errorf("Failed to convert count docs to count entries: %v", err)
 		}
 		countEntry := countEntries[0]
-		assert.Equal(t, int64(numWithinBucket+1), countEntry.Occurrences)
-		assert.Equal(t, int64(numWithinBucket), countEntry.CoOccurrences)
+		assert.Equal(t, int64(2), countEntry.Occurrences)
+		assert.Equal(t, int64(1), countEntry.CoOccurrences)
 	})
 
 	t.Run("should not add occurrences for misses if no co-occurrences have been found", func(t *testing.T) {
@@ -321,111 +221,6 @@ func TestSpanCount(t *testing.T) {
 
 	ac := client.NewAugurClientImpl(es, client.Immediate)
 	cs := countService.NewCountService(ac, logger)
-	t.Run("should be able to count co-occurrences of logs within the same timespan", func(t *testing.T) {
-		err := deleteAllDocuments(es)
-		if err != nil {
-			t.Errorf("Failed to delete all documents: %v", err)
-		}
-		numWithinBucket := 4
-		numOutsideBucket := 2
-		initialTime := time.Date(2021, 1, 1, 0, 0, 0, 204, time.UTC)
-		newSpan := spanModel.Span{
-			EndTime:   initialTime.Add(time.Second * 2),
-			StartTime: initialTime.Add(-time.Second * 2),
-			ClusterId: "initialClusterId",
-		}
-		logsOfSameTimeSpan := makeLogsOfSameClusterId(
-			"differentTime",
-			initialTime.Add(time.Second),
-			numWithinBucket,
-		)
-		logsOfDifferentTime := makeLogsOfSameClusterId(
-			"differentTime",
-			initialTime.Add(time.Second*4),
-			numOutsideBucket,
-		)
-		err = loadDataIntoElasticsearch(ac, []spanModel.Span{newSpan})
-		if err != nil {
-			t.Error("Failed to load span into elasticsearch")
-		}
-		err = loadDataIntoElasticsearch(ac, append(logsOfSameTimeSpan, logsOfDifferentTime...))
-		if err != nil {
-			t.Error("Failed to load logs into elasticsearch")
-		}
-		buckets := []countService.Bucket{2500}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		countInfo, err := cs.CountOccurrencesAndCoOccurrencesByCoClusterId(
-			ctx,
-			newSpan.ClusterId,
-			countModel.TimeInfo{
-				SpanInfo: &countModel.SpanInfo{
-					FromTime: newSpan.StartTime, ToTime: newSpan.EndTime,
-				},
-			},
-			buckets,
-		)
-		if err != nil {
-			t.Errorf("Failed to count occurrences: %v", err)
-		}
-		relevantCountInfo := countInfo["differentTime"]
-		assert.Equal(t, int64(len(logsOfSameTimeSpan)), relevantCountInfo.Occurrences)
-		assert.Equal(t, int64(len(logsOfSameTimeSpan)), relevantCountInfo.CoOccurrences)
-	})
-
-	t.Run("should be able to count co-occurrences of overlapping spans", func(t *testing.T) {
-		err := deleteAllDocuments(es)
-		if err != nil {
-			t.Errorf("Failed to delete all documents: %v", err)
-		}
-		numWithinBucket := 4
-		numOutsideBucket := 3
-		initialTime := time.Date(2021, 1, 1, 0, 0, 0, 204, time.UTC)
-		newSpan := spanModel.Span{
-			EndTime:   initialTime.Add(time.Second * 2),
-			StartTime: initialTime.Add(-time.Second * 2),
-			ClusterId: "initialClusterId",
-		}
-		overlappingSpans := makeSpansOfSameClusterId(
-			"differentTime",
-			initialTime.Add(time.Second),
-			initialTime.Add(time.Second*4),
-			numWithinBucket,
-		)
-		nonOverlappingSpans := makeSpansOfSameClusterId(
-			"differentTime",
-			initialTime.Add(time.Second*3),
-			initialTime.Add(time.Second*9),
-			numOutsideBucket,
-		)
-		err = loadDataIntoElasticsearch(ac, []spanModel.Span{newSpan})
-		if err != nil {
-			t.Error("Failed to load span into elasticsearch")
-		}
-		err = loadDataIntoElasticsearch(ac, append(overlappingSpans, nonOverlappingSpans...))
-		if err != nil {
-			t.Error("Failed to load overlapping spans into elasticsearch")
-		}
-		buckets := []countService.Bucket{1000}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		countInfo, err := cs.CountOccurrencesAndCoOccurrencesByCoClusterId(
-			ctx,
-			newSpan.ClusterId,
-			countModel.TimeInfo{
-				SpanInfo: &countModel.SpanInfo{
-					FromTime: newSpan.StartTime, ToTime: newSpan.EndTime,
-				},
-			},
-			buckets,
-		)
-		if err != nil {
-			t.Errorf("Failed to count occurrences: %v", err)
-		}
-		relevantCountInfo := countInfo["differentTime"]
-		assert.Equal(t, int64(len(overlappingSpans)), relevantCountInfo.Occurrences)
-		assert.Equal(t, int64(len(overlappingSpans)), relevantCountInfo.CoOccurrences)
-	})
 
 	t.Run("should update existing entries in the database", func(t *testing.T) {
 		err := deleteAllDocuments(es)
@@ -508,8 +303,8 @@ func TestSpanCount(t *testing.T) {
 			t.Errorf("Failed to convert count docs to count entries: %v", err)
 		}
 		countEntry := countEntries[0]
-		assert.Equal(t, int64(len(overlappingSpans)*2), countEntry.Occurrences)
-		assert.Equal(t, int64(len(overlappingSpans)*2), countEntry.CoOccurrences)
+		assert.Equal(t, int64(2), countEntry.Occurrences)
+		assert.Equal(t, int64(2), countEntry.CoOccurrences)
 	})
 }
 

--- a/backend/integration_test/elasticsearch/count_service_test.go
+++ b/backend/integration_test/elasticsearch/count_service_test.go
@@ -16,6 +16,8 @@ import (
 	"time"
 )
 
+var indices = []string{bootstrapper.LogIndexName, bootstrapper.CountIndexName}
+
 func TestLogCount(t *testing.T) {
 	if es == nil {
 		t.Error("es is uninitialized or otherwise nil")
@@ -52,6 +54,7 @@ func TestLogCount(t *testing.T) {
 			ctx,
 			newLog.ClusterId,
 			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
+			indices,
 			buckets,
 		)
 		if err != nil {
@@ -65,6 +68,7 @@ func TestLogCount(t *testing.T) {
 			ctx,
 			newLog.ClusterId,
 			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
+			indices,
 			buckets,
 		)
 		if err != nil {
@@ -125,6 +129,7 @@ func TestLogCount(t *testing.T) {
 			firstCtx,
 			newLog.ClusterId,
 			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
+			indices,
 			buckets,
 		)
 		if err != nil {
@@ -266,6 +271,7 @@ func TestSpanCount(t *testing.T) {
 					FromTime: newSpan.StartTime, ToTime: newSpan.EndTime,
 				},
 			},
+			indices,
 			buckets,
 		)
 		if err != nil {
@@ -283,6 +289,7 @@ func TestSpanCount(t *testing.T) {
 					FromTime: newSpan.StartTime, ToTime: newSpan.EndTime,
 				},
 			},
+			indices,
 			buckets,
 		)
 		err = ac.BulkIndex(ctx, res.MetaMapList, res.DocumentMapList, bootstrapper.CountIndexName)
@@ -344,6 +351,7 @@ func TestAlgorithm(t *testing.T) {
 			ctx,
 			newLog.ClusterId,
 			countModel.TimeInfo{LogInfo: &countModel.LogInfo{Timestamp: newLog.Timestamp}},
+			indices,
 			buckets,
 		)
 		if err != nil {

--- a/backend/pkg/count/model/query_details.go
+++ b/backend/pkg/count/model/query_details.go
@@ -7,13 +7,13 @@ type IncreaseMissesInput struct {
 	CoClusterIdsToExclude []string
 }
 
-type GetCountAndUpdateOccurrencesQueryConstituentsResult struct {
+type GetCountAndUpdateQueryDetails struct {
 	IncreaseIncrementForMissesInput IncreaseMissesInput
 	MetaMapList                     []client.MetaMap
 	DocumentMapList                 []client.DocumentMap
 }
 
-type GetMetaAndDocumentInfoForIncrementMissesQueryResult struct {
+type GetIncrementMissesQueryDetails struct {
 	MetaMapList     []client.MetaMap
 	DocumentMapList []client.DocumentMap
 }

--- a/backend/pkg/count/service/count_service.go
+++ b/backend/pkg/count/service/count_service.go
@@ -13,8 +13,6 @@ import (
 
 const csTimeOut = 2 * time.Second
 
-var indices = []string{bootstrapper.LogIndexName, bootstrapper.SpanIndexName}
-
 type CountService struct {
 	ac     client.AugurClient
 	logger *zap.Logger
@@ -37,15 +35,22 @@ func (cs *CountService) GetCountAndUpdateOccurrencesQueryConstituents(
 	ctx context.Context,
 	clusterId string,
 	timeInfo model.TimeInfo,
+	indices []string,
 	buckets []Bucket,
-) (*model.GetCountAndUpdateOccurrencesQueryConstituentsResult, error) {
-	countMap, err := cs.countOccurrencesAndCoOccurrencesByCoClusterId(ctx, clusterId, timeInfo, buckets)
+) (*model.GetCountAndUpdateQueryDetails, error) {
+	coClusterIds, err := cs.countOccurrencesAndCoOccurrencesByCoClusterId(
+		ctx,
+		clusterId,
+		timeInfo,
+		indices,
+		buckets,
+	)
 	if err != nil {
 		return nil, err
 	}
-	metaMapList, documentMapList := cs.getUpdateCoOccurrencesQueryConstituents(clusterId, countMap)
-	increaseForMissesInput := getIncrementOccurrencesForMissesInput(clusterId, countMap)
-	result := &model.GetCountAndUpdateOccurrencesQueryConstituentsResult{
+	metaMapList, documentMapList := cs.getUpdateCoOccurrencesQueryConstituents(clusterId, coClusterIds)
+	increaseForMissesInput := getIncrementOccurrencesForMissesInput(clusterId, coClusterIds)
+	result := &model.GetCountAndUpdateQueryDetails{
 		IncreaseIncrementForMissesInput: increaseForMissesInput,
 		MetaMapList:                     metaMapList,
 		DocumentMapList:                 documentMapList,
@@ -55,28 +60,22 @@ func (cs *CountService) GetCountAndUpdateOccurrencesQueryConstituents(
 
 func getIncrementOccurrencesForMissesInput(
 	clusterId string,
-	countMap map[string]struct{},
+	coOccurringClusterIds []string,
 ) model.IncreaseMissesInput {
-	clusterIds := make([]string, len(countMap))
-	i := 0
-	for key, _ := range countMap {
-		clusterIds[i] = key
-		i++
-	}
 	return model.IncreaseMissesInput{
 		ClusterId:             clusterId,
-		CoClusterIdsToExclude: clusterIds,
+		CoClusterIdsToExclude: coOccurringClusterIds,
 	}
 }
 
 func (cs *CountService) getUpdateCoOccurrencesQueryConstituents(
 	clusterId string,
-	countMap map[string]struct{},
+	coClusterIds []string,
 ) ([]client.MetaMap, []client.DocumentMap) {
-	metaMap := make([]client.MetaMap, len(countMap))
-	updateMap := make([]client.DocumentMap, len(countMap))
+	metaMap := make([]client.MetaMap, len(coClusterIds))
+	updateMap := make([]client.DocumentMap, len(coClusterIds))
 	i := 0
-	for otherClusterId, _ := range countMap {
+	for _, otherClusterId := range coClusterIds {
 		compositeId := getIDFromConstituents(clusterId, otherClusterId)
 		meta, update := buildUpdateClusterCountsQuery(compositeId, clusterId, otherClusterId)
 		metaMap[i] = meta
@@ -90,9 +89,10 @@ func (cs *CountService) countOccurrencesAndCoOccurrencesByCoClusterId(
 	ctx context.Context,
 	clusterId string,
 	timeInfo model.TimeInfo,
+	indices []string,
 	buckets []Bucket,
-) (map[string]struct{}, error) {
-	var coOccurringClustersByClusterId map[string]struct{}
+) ([]string, error) {
+	var coOccurringClusterIds = make([]string, 0)
 	for _, bucket := range buckets {
 		calculatedTimeInfo, err := getTimeRangeForBucket(timeInfo, bucket)
 		if err != nil {
@@ -104,7 +104,7 @@ func (cs *CountService) countOccurrencesAndCoOccurrencesByCoClusterId(
 			return nil, fmt.Errorf("error calculating time range for bucket: %w", err)
 		}
 		fromTime, toTime := calculatedTimeInfo.FromTime, calculatedTimeInfo.ToTime
-		coOccurringClusters, err := cs.getCoOccurringCluster(ctx, clusterId, fromTime, toTime)
+		coOccurringClusters, err := cs.getCoOccurringCluster(ctx, clusterId, indices, fromTime, toTime)
 		if err != nil {
 			cs.logger.Error(
 				"Failed to get co-occurring clusters",
@@ -113,18 +113,15 @@ func (cs *CountService) countOccurrencesAndCoOccurrencesByCoClusterId(
 			)
 			return nil, err
 		}
-		coOccurringClustersByClusterId = groupCoOccurringClustersByClusterId(coOccurringClusters)
-		// TODO: Just return a list of strings after testing
-		if len(coOccurringClustersByClusterId) != len(coOccurringClusters) {
-			cs.logger.Fatal("Duplicate co-occurring clusters found")
-		}
+		coOccurringClusterIds = append(coOccurringClusterIds, getCoOccurringClusterIds(coOccurringClusters)...)
 	}
-	return coOccurringClustersByClusterId, nil
+	return coOccurringClusterIds, nil
 }
 
 func (cs *CountService) getCoOccurringCluster(
 	ctx context.Context,
 	clusterId string,
+	indices []string,
 	fromTime time.Time,
 	toTime time.Time,
 ) ([]model.Cluster, error) {
@@ -164,8 +161,8 @@ func (cs *CountService) getCoOccurringCluster(
 func (cs *CountService) GetIncrementMissesQueryInfo(
 	ctx context.Context,
 	input model.IncreaseMissesInput,
-) (*model.GetMetaAndDocumentInfoForIncrementMissesQueryResult, error) {
-	missingCoClusterIds, err := cs.getNonMatchingCoClusterIds(ctx, input.ClusterId, input.CoClusterIdsToExclude)
+) (*model.GetIncrementMissesQueryDetails, error) {
+	missingCoClusterIds, err := cs.getNonMatchingCoClusterIds(ctx, input)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +171,7 @@ func (cs *CountService) GetIncrementMissesQueryInfo(
 	}
 
 	metaMapList, documentMapList := cs.getIncrementMissesDetails(input.ClusterId, missingCoClusterIds)
-	result := model.GetMetaAndDocumentInfoForIncrementMissesQueryResult{
+	result := model.GetIncrementMissesQueryDetails{
 		MetaMapList:     metaMapList,
 		DocumentMapList: documentMapList,
 	}
@@ -184,9 +181,9 @@ func (cs *CountService) GetIncrementMissesQueryInfo(
 
 func (cs *CountService) getNonMatchingCoClusterIds(
 	ctx context.Context,
-	clusterId string,
-	listOfCoOccurringClusters []string,
+	input model.IncreaseMissesInput,
 ) ([]model.Cluster, error) {
+	clusterId, listOfCoOccurringClusters := input.ClusterId, input.CoClusterIdsToExclude
 	incrementQuery := buildGetNonMatchedCoClusterIdsQuery(
 		clusterId,
 		listOfCoOccurringClusters,
@@ -202,9 +199,8 @@ func (cs *CountService) getNonMatchingCoClusterIds(
 	}
 	searchCtx, searchCancel := context.WithTimeout(ctx, csTimeOut)
 	defer searchCancel()
-	queryIndices := []string{bootstrapper.CountIndexName}
 	querySize := 10000
-	res, err := cs.ac.Search(searchCtx, string(queryBody), queryIndices, &querySize)
+	res, err := cs.ac.Search(searchCtx, string(queryBody), []string{bootstrapper.CountIndexName}, &querySize)
 	nonMatchingCoClusters, err := convertDocsToCoClusters(res)
 	if err != nil {
 		cs.logger.Error(
@@ -235,14 +231,12 @@ func (cs *CountService) getIncrementMissesDetails(
 	return metaMap, updateMap
 }
 
-func groupCoOccurringClustersByClusterId(clusters []model.Cluster) map[string]struct{} {
-	coOccurringClustersByClusterId := make(map[string]struct{})
-	for _, cluster := range clusters {
-		if _, ok := coOccurringClustersByClusterId[cluster.ClusterId]; !ok {
-			coOccurringClustersByClusterId[cluster.ClusterId] = struct{}{}
-		}
+func getCoOccurringClusterIds(clusters []model.Cluster) []string {
+	coOccurringClustersIds := make([]string, len(clusters))
+	for i, cluster := range clusters {
+		coOccurringClustersIds[i] = cluster.ClusterId
 	}
-	return coOccurringClustersByClusterId
+	return coOccurringClustersIds
 }
 
 func convertDocsToClusters(res []map[string]interface{}) ([]model.Cluster, error) {

--- a/backend/pkg/count/service/query_builder.go
+++ b/backend/pkg/count/service/query_builder.go
@@ -50,6 +50,9 @@ func buildGetCoOccurringClustersQuery(clusterId string, fromTime time.Time, toTi
 				"minimum_should_match": 1,
 			},
 		},
+		"collapse": map[string]interface{}{
+			"field": "cluster_id", // Collapse results by unique cluster_id
+		},
 		"_source": []string{"cluster_id"}, // Retrieve only the cluster IDs
 	}
 }
@@ -106,22 +109,20 @@ func buildUpdateClusterCountsQuery(
 	id string,
 	clusterId string,
 	otherClusterId string,
-	countInfo CountInfo,
 ) (client.MetaMap, client.DocumentMap) {
 	updateStatement := map[string]interface{}{
 		"script": map[string]interface{}{
-			"source": "ctx._source.occurrences += params.occurrences; ctx._source.co_occurrences += params.co_occurrences",
+			"source": "ctx._source.occurrences += params.increment; ctx._source.co_occurrences += params.increment",
 			"params": map[string]interface{}{
-				"occurrences":    countInfo.Occurrences,
-				"co_occurrences": countInfo.CoOccurrences,
+				"increment": 1,
 			},
 		},
 		"upsert": map[string]interface{}{
 			"created_at":     time.Now().UTC(),
 			"cluster_id":     clusterId,
 			"co_cluster_id":  otherClusterId,
-			"occurrences":    countInfo.Occurrences,
-			"co_occurrences": countInfo.CoOccurrences,
+			"occurrences":    1,
+			"co_occurrences": 1,
 		},
 	}
 


### PR DESCRIPTION
If we have two clusters, cluster A and B

Let's say we have the following scenarios that are within a timespan of each other

A    B
1     5

A    B
x     1

Then afterwards, we have the following counts in each step

A
co-occurrences: 1
occurrences: 1

B
co-occurrences: 5
occurrences: 5

then after the final step

A
co-occurrences: 1
occurrences: 1

B
co-occurrences: 5
occurrences: 6

This is what the new code does. Originally, the co-occurrences would always mirror each other and count for the denominator.